### PR TITLE
Changes in installation syntax

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -33,7 +33,7 @@ pacman::p_install_gh("appliedepi/epirhandbook")
 Or
 ``` r
 install.packages("remotes")
-remotes::install_git("appliedepi/epirhandbook")
+remotes::install_github("appliedepi/epirhandbook")
 ```
 
 # Licence


### PR DESCRIPTION
The syntax for installation via GitHub is remotes::install_github("appliedepi/epirhandbook") 
instead of remotes::install_git("appliedepi/epirhandbook")